### PR TITLE
Add prime-focus feed

### DIFF
--- a/fazel_file_generator/fazel_file_creator.py
+++ b/fazel_file_generator/fazel_file_creator.py
@@ -68,7 +68,7 @@ def main(args=None):
         type=str,
         default="chime",
         help="Which feed? (defaults to CHIME)",
-        choices=["chime", "prime", "hirax", "4m", "xmas"],
+        choices=["chime", "prime"],
     )
     parser.add_argument(
         "-hs",
@@ -182,9 +182,6 @@ def main(args=None):
     if args.feed == "chime":
         dalt0 = -3.45 * u.deg
         daz0 = -3.25 * u.deg
-    elif args.feed == "xmas":
-        dalt0 = -3.45 * u.deg
-        daz0 = 3.25 * u.deg
     else:
         dalt0 = 0 * u.deg
         daz0 = 0 * u.deg

--- a/fazel_file_generator/fazel_file_creator.py
+++ b/fazel_file_generator/fazel_file_creator.py
@@ -68,7 +68,7 @@ def main(args=None):
         type=str,
         default="chime",
         help="Which feed? (defaults to CHIME)",
-        choices=["chime", "hirax", "4m", "xmas"],
+        choices=["chime", "prime", "hirax", "4m", "xmas"],
     )
     parser.add_argument(
         "-hs",


### PR DESCRIPTION
Add an explicit option for the prime focus to the list of possible option for the `--feed` argument.

This doesn't add any logic (the option will be handled by the `else` clause of the feed selection, which sets the offsets to zero), but it makes the option show up in the help information.

In addition, we could consider removing feeds that are no longer used (`hirax`, `4m`, `xmas`). What does `4m` refer to, btw?